### PR TITLE
[BUGFIX] concatenate rshopts in isNodeAlive()

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: parallelly
-Version: 1.36.0-9002
+Version: 1.36.0-9003
 Title: Enhancing the 'parallel' Package
 Imports:
     parallel,

--- a/R/isNodeAlive.R
+++ b/R/isNodeAlive.R
@@ -106,7 +106,7 @@ isNodeAlive.RichSOCKnode <- function(x, timeout = 0.0, ...) {
 
   rshopts <- args_org$rshopts
   if (length(args_org$user) == 1L) rshopts <- c("-l", args_org$user, rshopts)
-  rsh_call <- paste(paste(shQuote(rshcmd), collapse = " "), rshopts, worker)
+  rsh_call <- paste(paste(shQuote(rshcmd), collapse = " "), paste(rshopts, collapse = " "), worker)
   debug && mdebugf("- Command to connect to the other host: %s", rsh_call)
   stop_if_not(length(rsh_call) == 1L)
 


### PR DESCRIPTION
To prevent `Error: ‘length(rsh_call) == 1L’ is not TRUE` produced by `isNodeAlive()` in conjunction with clusters using the `user` and/or `rshopts` arguments of `makeClusterPSOCK()`, concatenate the contents of character vector `rshopts` during creation of the full `rsh_call`.